### PR TITLE
Publish schema reload event and rebuild dataset

### DIFF
--- a/src/main/java/io/github/sandeeplakka/mockify/service/DatasetBuilder.java
+++ b/src/main/java/io/github/sandeeplakka/mockify/service/DatasetBuilder.java
@@ -3,6 +3,7 @@ package io.github.sandeeplakka.mockify.service;
 import io.github.sandeeplakka.mockify.generator.GeneratorRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
@@ -22,6 +23,13 @@ public class DatasetBuilder {
 
     @PostConstruct
     public void init() {
+        buildRows();
+        wireFKs();
+    }
+
+    @EventListener
+    public void onSchemaReloaded(SchemaReloadedEvent event) {
+        data.clear();
         buildRows();
         wireFKs();
     }

--- a/src/main/java/io/github/sandeeplakka/mockify/service/SchemaReloadedEvent.java
+++ b/src/main/java/io/github/sandeeplakka/mockify/service/SchemaReloadedEvent.java
@@ -1,0 +1,12 @@
+package io.github.sandeeplakka.mockify.service;
+
+import io.github.sandeeplakka.mockify.schema.ModelCfg;
+
+import java.util.Map;
+
+/**
+ * Application event indicating that schema configuration has been reloaded.
+ * Contains the latest set of model configurations.
+ */
+public record SchemaReloadedEvent(Map<String, ModelCfg> configs) {
+}

--- a/src/main/java/io/github/sandeeplakka/mockify/service/SchemaService.java
+++ b/src/main/java/io/github/sandeeplakka/mockify/service/SchemaService.java
@@ -2,6 +2,7 @@ package io.github.sandeeplakka.mockify.service;
 
 import io.github.sandeeplakka.mockify.config.SchemaStorageProperties;
 import io.github.sandeeplakka.mockify.schema.ModelCfg;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -26,10 +27,13 @@ public class SchemaService {
     }
 
     private final SchemaStorageProperties props;
+    private final ApplicationEventPublisher publisher;
     private Map<String, ModelCfg> cfgs;
 
-    public SchemaService(SchemaStorageProperties props) {
+    public SchemaService(SchemaStorageProperties props,
+                         ApplicationEventPublisher publisher) {
         this.props = props;
+        this.publisher = publisher;
         cfgs = load();
     }
 
@@ -83,6 +87,7 @@ public class SchemaService {
             Files.createDirectories(p.getParent());
             Files.writeString(p, yaml.dump(newRoot));
             cfgs = load();                       // hot-reload
+            publisher.publishEvent(new SchemaReloadedEvent(cfgs));
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/src/test/java/io/github/sandeeplakka/mockify/service/DatasetBuilderRefreshTest.java
+++ b/src/test/java/io/github/sandeeplakka/mockify/service/DatasetBuilderRefreshTest.java
@@ -1,0 +1,63 @@
+package io.github.sandeeplakka.mockify.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class DatasetBuilderRefreshTest {
+
+    private static final Path schemaFile;
+
+    static {
+        try {
+            Path dir = Files.createTempDirectory("schema-test");
+            schemaFile = dir.resolve("schema.yml");
+            System.setProperty("mockify.schemaPath", schemaFile.toString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Autowired
+    private SchemaService schemaService;
+
+    @Autowired
+    private DatasetBuilder datasetBuilder;
+
+    @Test
+    void datasetRebuildsAfterSchemaSave() {
+        assertThat(datasetBuilder.get("user")).isEmpty();
+
+        Map<String, Object> root = Map.of(
+                "models", Map.of(
+                        "User", Map.of(
+                                "_count", 2,
+                                "fake", Map.of("name", "name")
+                        )
+                )
+        );
+
+        schemaService.saveYaml(root);
+        assertThat(datasetBuilder.get("user")).hasSize(2);
+
+        Map<String, Object> updated = Map.of(
+                "models", Map.of(
+                        "User", Map.of(
+                                "_count", 3,
+                                "fake", Map.of("name", "name")
+                        )
+                )
+        );
+
+        schemaService.saveYaml(updated);
+        assertThat(datasetBuilder.get("user")).hasSize(3);
+    }
+}


### PR DESCRIPTION
## Summary
- publish `SchemaReloadedEvent` whenever schema YAML is saved
- listen for schema reloads in `DatasetBuilder` to rebuild dataset
- add integration test verifying dataset rebuild after schema save

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adf8030f04832bb64b129ab14d4258