### PR TITLE
Handle null schema root and add empty file test

### DIFF
--- a/src/main/java/io/github/sandeeplakka/mockify/service/SchemaService.java
+++ b/src/main/java/io/github/sandeeplakka/mockify/service/SchemaService.java
@@ -47,6 +47,9 @@ public class SchemaService {
     /* ------------ I/O -------------------------------------------- */
     private Map<String, ModelCfg> load() {
         Map<String, Object> root = read();
+        if (root == null) {
+            root = Map.of("models", Map.of());
+        }
         Map<String, Object> raw = (Map<String, Object>) root.getOrDefault("models", Map.of());
 
         return raw.entrySet().stream().collect(Collectors.toMap(

--- a/src/test/java/io/github/sandeeplakka/mockify/SchemaServiceTests.java
+++ b/src/test/java/io/github/sandeeplakka/mockify/SchemaServiceTests.java
@@ -1,0 +1,25 @@
+package io.github.sandeeplakka.mockify;
+
+import io.github.sandeeplakka.mockify.config.SchemaStorageProperties;
+import io.github.sandeeplakka.mockify.service.SchemaService;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaServiceTests {
+
+    @Test
+    void loadEmptyFileReturnsEmptyConfig() throws IOException {
+        Path temp = Files.createTempFile("schema", ".yml");
+        SchemaStorageProperties props = new SchemaStorageProperties();
+        props.setSchemaPath(temp.toString());
+
+        SchemaService service = new SchemaService(props);
+
+        assertThat(service.cfgs()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Guard against null YAML root in `SchemaService`
- Add unit test ensuring empty schema files load without errors

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adf80ca048832b8f2948ec8cb3a3b5